### PR TITLE
Add React frontend for game

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+React + TypeScript + Vite application for The Last of Guss game.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+import { globalIgnores } from 'eslint/config'
+
+export default tseslint.config([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs['recommended-latest'],
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Last of Guss</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@chakra-ui/react": "^2.8.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "framer-motion": "^10.16.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.33.0",
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^5.0.0",
+    "eslint": "^9.33.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.3.0",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.39.1",
+    "vite": "^7.1.2"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import { Route, Routes, Navigate } from 'react-router-dom'
+import { Login } from './pages/Login'
+import { Rounds } from './pages/Rounds'
+import { Round } from './pages/Round'
+import { useAuth } from './store'
+
+export default function App() {
+  const user = useAuth((s) => s.user)
+  return (
+    <Routes>
+      <Route path="/" element={user ? <Navigate to="/rounds" /> : <Login />} />
+      <Route path="/rounds" element={user ? <Rounds /> : <Navigate to="/" />} />
+      <Route path="/rounds/:id" element={user ? <Round /> : <Navigate to="/" />} />
+    </Routes>
+  )
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,51 @@
+import type { User } from './store'
+
+export interface RoundInfo {
+  id: string
+  start: string
+  end: string
+  status: 'active' | 'cooldown' | 'finished'
+}
+
+export interface RoundDetails extends RoundInfo {
+  total: number
+  myPoints: number
+  winner?: { username: string; points: number }
+}
+
+export async function login(username: string, password: string): Promise<User> {
+  const res = await fetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ username, password }),
+  })
+  if (!res.ok) {
+    throw new Error((await res.json()).message)
+  }
+  return res.json()
+}
+
+export async function getRounds(): Promise<RoundInfo[]> {
+  const res = await fetch('/rounds', { credentials: 'include' })
+  if (!res.ok) throw new Error('failed')
+  return res.json()
+}
+
+export async function createRound() {
+  const res = await fetch('/rounds', { method: 'POST', credentials: 'include' })
+  if (!res.ok) throw new Error('failed')
+  return res.json()
+}
+
+export async function getRound(id: string): Promise<RoundDetails> {
+  const res = await fetch(`/rounds/${id}`, { credentials: 'include' })
+  if (!res.ok) throw new Error('failed')
+  return res.json()
+}
+
+export async function tap(id: string) {
+  const res = await fetch(`/rounds/${id}/tap`, { method: 'POST', credentials: 'include' })
+  if (!res.ok) throw new Error('failed')
+  return res.json()
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { ChakraProvider } from '@chakra-ui/react'
+import { BrowserRouter } from 'react-router-dom'
+import './index.css'
+import App from './App.tsx'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ChakraProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ChakraProvider>
+  </StrictMode>,
+)

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Box, Button, FormControl, FormLabel, Input, VStack, Text } from '@chakra-ui/react'
+import { login } from '../api'
+import { useAuth } from '../store'
+import { useNavigate } from 'react-router-dom'
+
+export function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const setUser = useAuth((s) => s.setUser)
+  const navigate = useNavigate()
+
+  const submit = async () => {
+    try {
+      const user = await login(username, password)
+      setUser(user)
+      navigate('/rounds')
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e)
+      setError(msg)
+    }
+  }
+
+  return (
+    <Box maxW="sm" mx="auto" mt={20} p={6} borderWidth="1px" borderRadius="lg">
+      <VStack spacing={4}>
+        <FormControl>
+          <FormLabel>Имя пользователя</FormLabel>
+          <Input value={username} onChange={(e) => setUsername(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Пароль</FormLabel>
+          <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </FormControl>
+        {error && <Text color="red.500">{error}</Text>}
+        <Button onClick={submit} width="full">
+          Войти
+        </Button>
+      </VStack>
+    </Box>
+  )
+}

--- a/frontend/src/pages/Round.tsx
+++ b/frontend/src/pages/Round.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Box, Heading, Text } from '@chakra-ui/react'
+import { getRound, tap } from '../api'
+import type { RoundDetails } from '../api'
+import { useAuth } from '../store'
+import { useParams } from 'react-router-dom'
+
+function format(diff: number) {
+  const m = String(Math.floor(diff / 60)).padStart(2, '0')
+  const s = String(diff % 60).padStart(2, '0')
+  return `${m}:${s}`
+}
+
+export function Round() {
+  const { id } = useParams<{ id: string }>()
+  const user = useAuth((s) => s.user)!
+  const [round, setRound] = useState<RoundDetails>()
+  const [remaining, setRemaining] = useState('')
+
+  const refresh = useCallback(async () => {
+    const data = await getRound(id!)
+    setRound(data)
+    const target = data.status === 'cooldown' ? new Date(data.start) : new Date(data.end)
+    const diff = Math.max(0, Math.floor((target.getTime() - Date.now()) / 1000))
+    setRemaining(format(diff))
+  }, [id])
+
+  useEffect(() => {
+    refresh()
+    const timer = setInterval(() => {
+      if (round) {
+        const target = round.status === 'cooldown' ? new Date(round.start) : new Date(round.end)
+        const diff = Math.max(0, Math.floor((target.getTime() - Date.now()) / 1000))
+        setRemaining(format(diff))
+      }
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [refresh, round])
+
+  const tapGoose = async () => {
+    const res = await tap(id!)
+    setRound((r) => (r ? { ...r, myPoints: res.points, total: r.total + res.points - r.myPoints } : r))
+  }
+
+  if (!round) return <Box p={4}>Загрузка...</Box>
+
+  return (
+    <Box maxW="md" mx="auto" mt={10} textAlign="center">
+      <Heading mb={4}>{round.status === 'finished' ? 'Раунд завершен' : round.status === 'active' ? 'Раунд' : 'Cooldown'}</Heading>
+      <Text mb={2}>{user.username}</Text>
+      <Box fontSize="6xl" cursor={round.status === 'active' ? 'pointer' : 'default'} onClick={round.status === 'active' ? tapGoose : undefined}>
+        🪿
+      </Box>
+      {round.status === 'active' && (
+        <>
+          <Text>Раунд активен!</Text>
+          <Text>До конца осталось: {remaining}</Text>
+          <Text>Мои очки - {round.myPoints}</Text>
+        </>
+      )}
+      {round.status === 'cooldown' && (
+        <>
+          <Text>Cooldown</Text>
+          <Text>до начала раунда {remaining}</Text>
+        </>
+      )}
+      {round.status === 'finished' && (
+        <Box mt={4} pt={4} borderTopWidth="1px">
+          <Text>Всего {round.total}</Text>
+          {round.winner && <Text>Победитель - {round.winner.username} {round.winner.points}</Text>}
+          <Text>Мои очки {round.myPoints}</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/pages/Rounds.tsx
+++ b/frontend/src/pages/Rounds.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { Box, Button, Heading, Link, Spinner, Stack, Text } from '@chakra-ui/react'
+import { createRound, getRounds } from '../api'
+import type { RoundInfo } from '../api'
+import { useAuth } from '../store'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+
+export function Rounds() {
+  const [rounds, setRounds] = useState<RoundInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const user = useAuth((s) => s.user)!
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    getRounds()
+      .then(setRounds)
+      .finally(() => setLoading(false))
+  }, [])
+
+  const create = async () => {
+    const round = await createRound()
+    navigate(`/rounds/${round.id}`)
+  }
+
+  return (
+    <Box maxW="3xl" mx="auto" mt={10}>
+      <Stack direction="row" justify="space-between" mb={4}>
+        <Heading size="lg">Список раундов</Heading>
+        <Text>{user.username}</Text>
+      </Stack>
+      {user.role === 'admin' && (
+        <Button mb={4} onClick={create}>
+          Создать раунд
+        </Button>
+      )}
+      {loading ? (
+        <Spinner />
+      ) : (
+        <Stack spacing={4}>
+          {rounds.map((r) => (
+            <Box key={r.id} p={4} borderWidth="1px" borderRadius="md">
+              <Link as={RouterLink} to={`/rounds/${r.id}`} fontWeight="bold">
+                Round ID: {r.id}
+              </Link>
+              <Text>Start: {new Date(r.start).toLocaleString()}</Text>
+              <Text>End: {new Date(r.end).toLocaleString()}</Text>
+              <Text mt={2}>Статус: {r.status}</Text>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+export type User = {
+  id: number
+  username: string
+  role: 'admin' | 'survivor' | 'nikita'
+}
+
+interface State {
+  user?: User
+  setUser: (user?: User) => void
+}
+
+export const useAuth = create<State>((set) => ({
+  user: undefined,
+  setUser: (user) => set({ user }),
+}))

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/login': 'http://localhost:3000',
+      '/rounds': 'http://localhost:3000',
+    },
+  },
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyRequest } from 'fastify';
+import Fastify from 'fastify';
 import cookie from '@fastify/cookie';
 import formbody from '@fastify/formbody';
 import dotenv from 'dotenv';
@@ -48,7 +48,7 @@ app.post('/login', async (req, reply) => {
   return { id: user.id, username: user.username, role: user.role };
 });
 
-app.get('/rounds', async (req) => {
+app.get('/rounds', async () => {
   const rounds = await prisma.round.findMany({ orderBy: { createdAt: 'desc' } });
   const now = new Date();
   return rounds.map((r) => ({


### PR DESCRIPTION
## Summary
- build React + TypeScript frontend using Vite
- implement login, round list, and round view pages
- wire up API calls and basic game UI with goose tapping

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0112b30d483319e87a39fab1d9dd8