### PR TITLE
refactor: migrate backend to Nest

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@
 
 ## Стек
 
-- Node.js + Fastify
+- Node.js + NestJS
 - TypeScript
 - Prisma + PostgreSQL
 - Redis для счётчиков

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,22 +9,27 @@
     "lint": "eslint \"src/**/*.ts\" --fix"
   },
   "dependencies": {
-    "fastify": "^4.27.2",
-    "@fastify/cookie": "^9.0.0",
-    "@fastify/formbody": "^7.4.0",
-    "dotenv": "^16.4.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.12.0",
-    "ioredis": "^5.4.1"
+    "cookie-parser": "^1.4.6",
+    "dotenv": "^16.4.0",
+    "ioredis": "^5.4.1",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
-    "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0",
-    "prisma": "^5.12.0",
-    "eslint": "^8.46.0",
+    "@types/cookie-parser": "^1.4.3",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.5.9",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
+    "eslint": "^8.46.0",
     "prettier": "^3.0.1",
-    "@types/node": "^20.5.9"
+    "prisma": "^5.12.0",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2"
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,17 @@
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { RoundsController } from './rounds.controller';
+import { PrismaService } from './prisma.service';
+import { RedisService } from './redis.service';
+import { AuthMiddleware } from './auth.middleware';
+
+@Module({
+  controllers: [AuthController, RoundsController],
+  providers: [PrismaService, RedisService],
+})
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+}
+

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Post, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { PrismaService } from './prisma.service';
+import { Role } from '@prisma/client';
+
+@Controller()
+export class AuthController {
+  constructor(private prisma: PrismaService) {}
+
+  @Post('login')
+  async login(@Body() body: any, @Res({ passthrough: true }) res: Response) {
+    const { username, password } = body;
+    if (!username || !password) {
+      res.status(400);
+      return { message: 'username and password required' };
+    }
+
+    let user = await this.prisma.user.findUnique({ where: { username } });
+    if (!user) {
+      const role =
+        username === 'admin'
+          ? Role.admin
+          : username === 'Никита' || username === 'Nikita'
+            ? Role.nikita
+            : Role.survivor;
+      user = await this.prisma.user.create({ data: { username, password, role } });
+    } else if (user.password !== password) {
+      res.status(401);
+      return { message: 'invalid password' };
+    }
+
+    res.cookie('uid', String(user.id), { path: '/' });
+    return { id: user.id, username: user.username, role: user.role };
+  }
+}
+

--- a/backend/src/auth.middleware.ts
+++ b/backend/src/auth.middleware.ts
@@ -1,0 +1,31 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { PrismaService } from './prisma.service';
+import { Role } from '@prisma/client';
+
+export interface RequestUser {
+  id: number;
+  role: Role;
+  username: string;
+}
+
+export interface AuthedRequest extends Request {
+  user?: RequestUser;
+}
+
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+  constructor(private prisma: PrismaService) {}
+
+  async use(req: AuthedRequest, res: Response, next: NextFunction) {
+    const uid = (req.cookies as any)?.uid;
+    if (uid) {
+      const user = await this.prisma.user.findUnique({ where: { id: Number(uid) } });
+      if (user) {
+        req.user = { id: user.id, role: user.role, username: user.username };
+      }
+    }
+    next();
+  }
+}
+

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,129 +1,16 @@
-import Fastify from 'fastify';
-import cookie from '@fastify/cookie';
-import formbody from '@fastify/formbody';
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
-import { prisma } from './prisma';
-import { redis } from './redis';
-import { Role } from '@prisma/client';
+import { AppModule } from './app.module';
 
-dotenv.config();
-
-const ROUND_DURATION = parseInt(process.env.ROUND_DURATION || '60', 10); // seconds
-const COOLDOWN_DURATION = parseInt(process.env.COOLDOWN_DURATION || '30', 10); // seconds
-
-const app = Fastify();
-app.register(cookie);
-app.register(formbody);
-
-// augment request type
-declare module 'fastify' {
-  interface FastifyRequest {
-    user?: { id: number; role: Role; username: string };
-  }
+async function bootstrap() {
+  dotenv.config();
+  const app = await NestFactory.create(AppModule);
+  app.use(cookieParser());
+  const port = Number(process.env.PORT) || 3000;
+  await app.listen(port, '0.0.0.0');
 }
 
-app.addHook('preHandler', async (req) => {
-  const uid = (req.cookies as any).uid;
-  if (uid) {
-    const user = await prisma.user.findUnique({ where: { id: Number(uid) } });
-    if (user) {
-      req.user = { id: user.id, role: user.role, username: user.username };
-    }
-  }
-});
+bootstrap();
 
-app.post('/login', async (req, reply) => {
-  const { username, password } = req.body as any;
-  if (!username || !password) {
-    return reply.status(400).send({ message: 'username and password required' });
-  }
-  let user = await prisma.user.findUnique({ where: { username } });
-  if (!user) {
-    const role = username === 'admin' ? Role.admin : username === 'Никита' || username === 'Nikita' ? Role.nikita : Role.survivor;
-    user = await prisma.user.create({ data: { username, password, role } });
-  } else if (user.password !== password) {
-    return reply.status(401).send({ message: 'invalid password' });
-  }
-  reply.setCookie('uid', String(user.id), { path: '/' });
-  return { id: user.id, username: user.username, role: user.role };
-});
-
-app.get('/rounds', async () => {
-  const rounds = await prisma.round.findMany({ orderBy: { createdAt: 'desc' } });
-  const now = new Date();
-  return rounds.map((r) => ({
-    id: r.id,
-    start: r.start,
-    end: r.end,
-    status: now < r.start ? 'cooldown' : now > r.end ? 'finished' : 'active',
-  }));
-});
-
-app.post('/rounds', async (req, reply) => {
-  if (!req.user || req.user.role !== Role.admin) {
-    return reply.status(403).send({ message: 'forbidden' });
-  }
-  const createdAt = new Date();
-  const start = new Date(createdAt.getTime() + COOLDOWN_DURATION * 1000);
-  const end = new Date(start.getTime() + ROUND_DURATION * 1000);
-  const round = await prisma.round.create({ data: { start, end, total: 0 } });
-  return round;
-});
-
-app.get('/rounds/:id', async (req, reply) => {
-  const { id } = req.params as any;
-  const round = await prisma.round.findUnique({ where: { id }, include: { scores: true } });
-  if (!round) return reply.status(404).send({ message: 'not found' });
-  const now = new Date();
-  const status = now < round.start ? 'cooldown' : now > round.end ? 'finished' : 'active';
-  const myScore = req.user ? round.scores.find((s) => s.userId === req.user!.id) : undefined;
-  let winner: any = undefined;
-  if (status === 'finished' && round.scores.length > 0) {
-    const top = round.scores.reduce((a, b) => (a.points > b.points ? a : b));
-    const user = await prisma.user.findUnique({ where: { id: top.userId } });
-    winner = { username: user?.username, points: top.points };
-  }
-  return {
-    id: round.id,
-    start: round.start,
-    end: round.end,
-    status,
-    total: round.total,
-    myPoints: myScore?.points || 0,
-    winner,
-  };
-});
-
-app.post('/rounds/:id/tap', async (req, reply) => {
-  if (!req.user) return reply.status(401).send({ message: 'unauthorized' });
-  const { id } = req.params as any;
-  const round = await prisma.round.findUnique({ where: { id } });
-  const now = new Date();
-  if (!round || now < round.start || now > round.end) {
-    return reply.status(400).send({ message: 'round not active' });
-  }
-  if (req.user.role === Role.nikita) {
-    return { points: 0 };
-  }
-  // use redis transaction for taps
-  const key = `round:${id}:user:${req.user.id}`;
-  const totalKey = `round:${id}:total`;
-  const lua = `local taps = redis.call('HINCRBY', KEYS[1], 'taps', 1)
-local add = 1
-if taps % 11 == 0 then add = add + 10 end
-local points = redis.call('HINCRBY', KEYS[1], 'points', add)
-redis.call('INCRBY', KEYS[2], add)
-return {taps, points, add}`;
-  const [taps, points, add] = (await redis.eval(lua, 2, key, totalKey)) as [number, number, number];
-  await prisma.roundScore.upsert({
-    where: { roundId_userId: { roundId: id, userId: req.user.id } },
-    update: { taps, points },
-    create: { roundId: id, userId: req.user.id, taps, points },
-  });
-  await prisma.round.update({ where: { id }, data: { total: { increment: add } } });
-  return { points };
-});
-
-app.listen({ port: Number(process.env.PORT) || 3000, host: '0.0.0.0' }).then(() => {
-  console.log('Server running');
-});

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}
+

--- a/backend/src/prisma.ts
+++ b/backend/src/prisma.ts
@@ -1,3 +1,0 @@
-import { PrismaClient } from '@prisma/client';
-
-export const prisma = new PrismaClient();

--- a/backend/src/redis.service.ts
+++ b/backend/src/redis.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import Redis from 'ioredis';
+
+@Injectable()
+export class RedisService implements OnModuleDestroy {
+  private readonly client: Redis;
+
+  constructor() {
+    const url = process.env.REDIS_URL;
+    this.client = url ? new Redis(url) : new Redis();
+  }
+
+  get redis() {
+    return this.client;
+  }
+
+  async onModuleDestroy() {
+    await this.client.quit();
+  }
+}
+

--- a/backend/src/redis.ts
+++ b/backend/src/redis.ts
@@ -1,3 +1,0 @@
-import Redis from 'ioredis';
-
-export const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');

--- a/backend/src/rounds.controller.ts
+++ b/backend/src/rounds.controller.ts
@@ -1,0 +1,101 @@
+import { Controller, Get, Param, Post, Req, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { PrismaService } from './prisma.service';
+import { RedisService } from './redis.service';
+import { AuthedRequest } from './auth.middleware';
+import { Role } from '@prisma/client';
+
+const ROUND_DURATION = parseInt(process.env.ROUND_DURATION || '60', 10);
+const COOLDOWN_DURATION = parseInt(process.env.COOLDOWN_DURATION || '30', 10);
+
+@Controller('rounds')
+export class RoundsController {
+  constructor(private prisma: PrismaService, private redis: RedisService) {}
+
+  @Get()
+  async list() {
+    const rounds = await this.prisma.round.findMany({ orderBy: { createdAt: 'desc' } });
+    const now = new Date();
+    return rounds.map((r) => ({
+      id: r.id,
+      start: r.start,
+      end: r.end,
+      status: now < r.start ? 'cooldown' : now > r.end ? 'finished' : 'active',
+    }));
+  }
+
+  @Post()
+  async create(@Req() req: AuthedRequest, @Res() res: Response) {
+    if (!req.user || req.user.role !== Role.admin) {
+      return res.status(403).json({ message: 'forbidden' });
+    }
+    const createdAt = new Date();
+    const start = new Date(createdAt.getTime() + COOLDOWN_DURATION * 1000);
+    const end = new Date(start.getTime() + ROUND_DURATION * 1000);
+    const round = await this.prisma.round.create({ data: { start, end, total: 0 } });
+    return res.json(round);
+  }
+
+  @Get(':id')
+  async getOne(@Param('id') id: string, @Req() req: AuthedRequest, @Res() res: Response) {
+    const round = await this.prisma.round.findUnique({ where: { id }, include: { scores: true } });
+    if (!round) {
+      return res.status(404).json({ message: 'not found' });
+    }
+    const now = new Date();
+    const status = now < round.start ? 'cooldown' : now > round.end ? 'finished' : 'active';
+    const myScore = req.user ? round.scores.find((s) => s.userId === req.user!.id) : undefined;
+    let winner: any = undefined;
+    if (status === 'finished' && round.scores.length > 0) {
+      const top = round.scores.reduce((a, b) => (a.points > b.points ? a : b));
+      const user = await this.prisma.user.findUnique({ where: { id: top.userId } });
+      winner = { username: user?.username, points: top.points };
+    }
+    return res.json({
+      id: round.id,
+      start: round.start,
+      end: round.end,
+      status,
+      total: round.total,
+      myPoints: myScore?.points || 0,
+      winner,
+    });
+  }
+
+  @Post(':id/tap')
+  async tap(@Param('id') id: string, @Req() req: AuthedRequest, @Res() res: Response) {
+    if (!req.user) {
+      return res.status(401).json({ message: 'unauthorized' });
+    }
+    const round = await this.prisma.round.findUnique({ where: { id } });
+    const now = new Date();
+    if (!round || now < round.start || now > round.end) {
+      return res.status(400).json({ message: 'round not active' });
+    }
+    if (req.user.role === Role.nikita) {
+      return res.json({ points: 0 });
+    }
+
+    const key = `round:${id}:user:${req.user.id}`;
+    const totalKey = `round:${id}:total`;
+    const lua = `local taps = redis.call('HINCRBY', KEYS[1], 'taps', 1)
+local add = 1
+if taps % 11 == 0 then add = add + 10 end
+local points = redis.call('HINCRBY', KEYS[1], 'points', add)
+redis.call('INCRBY', KEYS[2], add)
+return {taps, points, add}`;
+    const [taps, points, add] = (await this.redis.redis.eval(lua, 2, key, totalKey)) as [
+      number,
+      number,
+      number,
+    ];
+    await this.prisma.roundScore.upsert({
+      where: { roundId_userId: { roundId: id, userId: req.user.id } },
+      update: { taps, points },
+      create: { roundId: id, userId: req.user.id, taps, points },
+    });
+    await this.prisma.round.update({ where: { id }, data: { total: { increment: add } } });
+    return res.json({ points });
+  }
+}
+

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,7 +5,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- migrate backend from Fastify to NestJS
- implement login, round management, and goose tap routes
- add Prisma and Redis services with cookie-based auth middleware

## Testing
- `npm run build`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68b020b8dd6c8331a1297d86790522c4